### PR TITLE
Convert aws-lambda-powertools-feedstock to v1 feedstock, adjust dependencies

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -7,4 +7,4 @@ channel_targets:
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
 python_min:
-- '3.9'
+- '3.10'

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @BastianZim
+* @BastianZim @pavelzw

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,21 @@ pkgs_dirs:
 solver: libmamba
 
 CONDARC
-mv /opt/conda/conda-meta/history /opt/conda/conda-meta/history.$(date +%Y-%m-%d-%H-%M-%S)
-echo > /opt/conda/conda-meta/history
-micromamba install --root-prefix ~/.conda --prefix /opt/conda \
-    --yes --override-channels --channel conda-forge --strict-channel-priority \
-    pip  python=3.12 conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
+curl -fsSL https://pixi.sh/install.sh | bash
+export PATH="~/.pixi/bin:$PATH"
+pushd "${FEEDSTOCK_ROOT}"
+arch=$(uname -m)
+if [[ "$arch" == "x86_64" ]]; then
+  arch="64"
+fi
+sed -i.bak -e "s/platforms = .*/platforms = [\"linux-${arch}\"]/" -e "s/# __PLATFORM_SPECIFIC_ENV__ =/docker-build-linux-$arch =/" pixi.toml
+echo "Creating environment"
+PIXI_CACHE_DIR=/opt/conda pixi install --environment docker-build-linux-$arch
+pixi list
+echo "Activating environment"
+eval "$(pixi shell-hook --environment docker-build-linux-$arch)"
+mv pixi.toml.bak pixi.toml
+popd
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 # set up the condarc
@@ -57,20 +67,16 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
 fi
 
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
-    if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
-        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"
-    fi
-    conda debug "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml"
-
-    # Drop into an interactive shell
-    /bin/bash
+    echo "rattler-build currently doesn't support debug mode"
 else
-    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-        --suppress-variables ${EXTRA_CB_OPTIONS:-} \
-        --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
-        --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"
+
+    rattler-build build --recipe "${RECIPE_ROOT}" \
+     -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+     ${EXTRA_CB_OPTIONS:-} \
+     --target-platform "${HOST_PLATFORM}" \
+     --extra-meta flow_run_id="${flow_run_id:-}" \
+     --extra-meta remote_url="${remote_url:-}" \
+     --extra-meta sha="${sha:-}"
     ( startgroup "Inspecting artifacts" ) 2> /dev/null
 
     # inspect_artifacts was only added in conda-forge-ci-setup 4.9.4

--- a/README.md
+++ b/README.md
@@ -151,4 +151,5 @@ Feedstock Maintainers
 =====================
 
 * [@BastianZim](https://github.com/BastianZim/)
+* [@pavelzw](https://github.com/pavelzw/)
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Documentation: https://awslabs.github.io/aws-lambda-powertools-python/api/
 A suite of Python utilities for AWS Lambda functions to ease adopting best practices such as tracing, structured logging,
 custom metrics, and more. ([AWS Lambda Powertools Java](https://github.com/awslabs/aws-lambda-powertools-java) is also available).
 
-
 Current build status
 ====================
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -6,3 +6,5 @@ conda_build:
   pkg_format: '2'
 bot:
   inspection: update-grayskull
+conda_install_tool: pixi
+conda_build_tool: rattler-build

--- a/pixi.toml
+++ b/pixi.toml
@@ -7,7 +7,7 @@
 
 [project]
 name = "aws-lambda-powertools-feedstock"
-version = "3.52.0"  # conda-smithy version used to generate this file
+version = "3.52.1"  # conda-smithy version used to generate this file
 description = "Pixi configuration for conda-forge/aws-lambda-powertools-feedstock"
 authors = ["@conda-forge/aws-lambda-powertools"]
 channels = ["conda-forge"]

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,54 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: toml -*-
+
+#                             VVVVVV  minimum `pixi` version
+"$schema" = "https://pixi.sh/v0.36.0/schema/manifest/schema.json"
+
+[project]
+name = "aws-lambda-powertools-feedstock"
+version = "3.52.0"  # conda-smithy version used to generate this file
+description = "Pixi configuration for conda-forge/aws-lambda-powertools-feedstock"
+authors = ["@conda-forge/aws-lambda-powertools"]
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-64", "win-64"]
+
+[dependencies]
+conda-build = ">=24.1"
+conda-forge-ci-setup = "4.*"
+rattler-build = "*"
+
+[tasks]
+[tasks.inspect-all]
+cmd = "inspect_artifacts --all-packages"
+description = "List contents of all packages found in rattler-build build directory."
+[tasks.build]
+cmd = "rattler-build build --recipe recipe"
+description = "Build aws-lambda-powertools-feedstock directly (without setup scripts), no particular variant specified"
+[tasks."build-linux_64_"]
+cmd = "rattler-build build --recipe recipe -m .ci_support/linux_64_.yaml"
+description = "Build aws-lambda-powertools-feedstock with variant linux_64_ directly (without setup scripts)"
+[tasks."inspect-linux_64_"]
+cmd = "inspect_artifacts --recipe-dir recipe -m .ci_support/linux_64_.yaml"
+description = "List contents of aws-lambda-powertools-feedstock packages built for variant linux_64_"
+
+[feature.smithy.dependencies]
+conda-smithy = "*"
+shellcheck = "*"
+[feature.smithy.tasks.build-locally]
+cmd = "python ./build-locally.py"
+description = "Build packages locally using the same setup scripts used in conda-forge's CI"
+[feature.smithy.tasks.smithy]
+cmd = "conda-smithy"
+description = "Run conda-smithy. Pass necessary arguments."
+[feature.smithy.tasks.rerender]
+cmd = "conda-smithy rerender"
+description = "Rerender the feedstock."
+[feature.smithy.tasks.lint]
+cmd = "conda-smithy lint --conda-forge recipe"
+description = "Lint the feedstock recipe"
+
+[environments]
+smithy = ["smithy"]
+# This is a copy of default, to be enabled by build_steps.sh during Docker builds
+# __PLATFORM_SPECIFIC_ENV__ = []

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -23,29 +23,32 @@ requirements:
     - poetry-core >=1.3.2
     - pip
   run:
+    - python >=${{ python_min }}
     - typing_extensions >=4.11.0,<5.0.0
     - jmespath >=1.0.1,<2.0.0
-    - python >=${{ python_min }},<4.0.0
-    - typing-extensions >=4.11.0,<5.0.0
+  run_constraints:
     # Extra: parser
-    - pydantic >=2.0.3,<2.1
-    # Extra: tracer
-    - aws-xray-sdk >=2.8.0,<3.0.0
+    - pydantic >=2.4.0,<3
+    - pydantic-settings >=2.6.1,<3
     # Extra: validation
-    - python-fastjsonschema >=2.14.5,<3.0.0
-    # Extra: aws-sdk
-    - boto3 >=1.34.32,<2.0.0
-    # Extra: datamasking
-    - aws-encryption-sdk >=3.1.1,<5.0.0
-    - jsonpath-ng >=1.6.0,<2
-    # Extra: afka-consumer-avro
-    - avro >=1.12.0,<2
+    - python-fastjsonschema >=2.14.5,<3
+    # Extra: tracer
+    - aws-xray-sdk >=2.8.0,<3
     # Extra: redis
     - redis-py >=4.4,<7.0
-  run_constraints:
-    - datadog-lambda >=4.77,<7.0
+    # Extra: aws-sdk
+    - boto3 >=1.34.32,<2.0.0
+    # Extra: valkey
     - valkey-glide >=1.3.5,<3.0
-    - protobuf >=6.30.2,<6.40
+    # datadog
+    - datadog-lambda >=6.106.0,<7.0
+    # Extra: datamasking
+    - aws-encryption-sdk >=3.1.1,<5
+    - jsonpath-ng >=1.6.0,<2
+    # Extra: kafka-consumer-avro
+    - avro >=1.12.0,<2
+    # Extra: kafka-consumer-protobuf
+    - protobuf >=6.30.2,<7
 
 tests:
   - python:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,75 +1,76 @@
-{% set name = "aws-lambda-powertools" %}
-{% set version = "3.19.0" %}
+schema_version: 1
 
+context:
+  name: aws-lambda-powertools
+  version: 3.19.0
 
 package:
-  name: {{ name|lower }}
-  version: {{ version }}
+  name: ${{ name|lower }}
+  version: ${{ version }}
 
 source:
-  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/aws_lambda_powertools-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/${{ name[0] }}/${{ name }}/aws_lambda_powertools-${{ version }}.tar.gz
   sha256: 8897ba4be0b3a51f2b8f68946d650f3ef574fa2c40395544de03bd0c61979999
 
 build:
+  number: 1
   noarch: python
-  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
-  number: 0
+  script: ${{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
-    - python {{ python_min }}
+    - python ${{ python_min }}.*
     - poetry-core >=1.3.2
     - pip
   run:
     - typing_extensions >=4.11.0,<5.0.0
     - jmespath >=1.0.1,<2.0.0
-    - python >={{ python_min }},<4.0.0
+    - python >=${{ python_min }},<4.0.0
     - typing-extensions >=4.11.0,<5.0.0
-# Extra: parser
+    # Extra: parser
     - pydantic >=2.0.3,<2.1
-# Extra: tracer
+    # Extra: tracer
     - aws-xray-sdk >=2.8.0,<3.0.0
-# Extra: validation
+    # Extra: validation
     - python-fastjsonschema >=2.14.5,<3.0.0
-# Extra: aws-sdk
+    # Extra: aws-sdk
     - boto3 >=1.34.32,<2.0.0
-# Extra: datamasking
+    # Extra: datamasking
     - aws-encryption-sdk >=3.1.1,<5.0.0
     - jsonpath-ng >=1.6.0,<2
-# Extra: afka-consumer-avro
+    # Extra: afka-consumer-avro
     - avro >=1.12.0,<2
-# Extra: redis
+    # Extra: redis
     - redis-py >=4.4,<7.0
-  run_constrained:
+  run_constraints:
     - datadog-lambda >=4.77,<7.0
-    # Proprietary software
     - valkey-glide >=1.3.5,<3.0
-    # Not yet available
-    # Extra: protobuf
     - protobuf >=6.30.2,<6.40
 
-test:
-  imports:
-    - aws_lambda_powertools
-  commands:
-    - pip check
-  requires:
-    - pip
-    - python {{ python_min }}
+tests:
+  - python:
+      imports:
+        - aws_lambda_powertools
+      python_version: ${{ python_min }}.*
+  - requirements:
+      run:
+        - pip
+        - python ${{ python_min }}.*
+    script:
+      - pip check
 
 about:
-  home: https://awslabs.github.io/aws-lambda-powertools-python/
   summary: Python utilities for AWS Lambda functions including but not limited to tracing, logging and custom metric
   description: |
     A suite of Python utilities for AWS Lambda functions to ease adopting best practices such as tracing, structured logging,
     custom metrics, and more. ([AWS Lambda Powertools Java](https://github.com/awslabs/aws-lambda-powertools-java) is also available).
   license: MIT-0 AND Apache-2.0
-  license_family: MIT
   license_file:
     - LICENSE
     - THIRD-PARTY-LICENSES
-  doc_url: https://awslabs.github.io/aws-lambda-powertools-python/api/
-  dev_url: https://github.com/awslabs/aws-lambda-powertools-python
+  homepage: https://awslabs.github.io/aws-lambda-powertools-python/
+  repository: https://github.com/awslabs/aws-lambda-powertools-python
+  documentation: https://awslabs.github.io/aws-lambda-powertools-python/api/
 
 extra:
   recipe-maintainers:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -78,3 +78,4 @@ about:
 extra:
   recipe-maintainers:
     - BastianZim
+    - pavelzw


### PR DESCRIPTION
This PR converts aws-lambda-powertools-feedstock to a v1 recipe and switch the conda build tool to rattler-build.
It has been automatically generated with [feedrattler v0.3.13](https://github.com/hadim/feedrattler).

Changes:
- [x] 📝 Converted `meta.yaml` to `recipe.yaml`
- [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
- [x] 🔧 Updated `conda-forge.yml` to use `rattler-build` and `pixi` (optional)
- [x] 🔢 Bumped the build number
- [x] 🐍 Applied temporary fixes for `python_min` and `python_version`
- [x] 🔄 Rerender the feedstock with conda-smithy
- [ ] Ensured the license file is being packaged.
